### PR TITLE
global: migration of _oaiid to _oai.id

### DIFF
--- a/invenio_oaiserver/fetchers.py
+++ b/invenio_oaiserver/fetchers.py
@@ -34,10 +34,11 @@ from .provider import OAIIDProvider
 
 def oaiid_fetcher(record_uuid, data):
     """Fetch a record's identifier."""
-    if '_oaiid' not in data:
+    pid_value = data.get('_oai', {}).get('id')
+    if pid_value is None:
         raise PersistentIdentifierError()
     return FetchedPID(
         provider=OAIIDProvider,
         pid_type=OAIIDProvider.pid_type,
-        pid_value=str(data['_oaiid']),
+        pid_value=str(pid_value),
     )

--- a/invenio_oaiserver/minters.py
+++ b/invenio_oaiserver/minters.py
@@ -41,5 +41,6 @@ def oaiid_minter(record_uuid, data):
         object_type='rec', object_uuid=record_uuid,
         pid_value=pid_value
     )
-    data['_oaiid'] = provider.pid.pid_value
+    data.setdefault('_oai', {})
+    data['_oai']['id'] = provider.pid.pid_value
     return provider.pid

--- a/invenio_oaiserver/receivers.py
+++ b/invenio_oaiserver/receivers.py
@@ -97,9 +97,8 @@ class OAIServerUpdater(object):
 
     def __call__(self, record, **kwargs):
         """Update sets list."""
-        record.update({
-            '_oai': {
-                'sets': get_record_sets(record=record, matcher=self.matcher),
-                'updated': datetime_to_datestamp(datetime.utcnow()),
-            }
+        record.setdefault('_oai', {})
+        record['_oai'].update({
+            'sets': get_record_sets(record=record, matcher=self.matcher),
+            'updated': datetime_to_datestamp(datetime.utcnow()),
         })


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>