### PR TITLE
provider: name length issue fix

### DIFF
--- a/invenio_oaiserver/provider.py
+++ b/invenio_oaiserver/provider.py
@@ -36,7 +36,7 @@ class OAIIDProvider(BaseProvider):
     pid_type = 'oai'
     """Type of persistent identifier."""
 
-    pid_provider = 'invenio_oaiserver'
+    pid_provider = 'oai'
     """Provider name."""
 
     default_status = PIDStatus.RESERVED


### PR DESCRIPTION
* Fixes provider name to be less than 8 characters.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>