### PR TITLE
response: GetRecord envelope fix

### DIFF
--- a/invenio_oaiserver/response.py
+++ b/invenio_oaiserver/response.py
@@ -266,14 +266,15 @@ def getrecord(**kwargs):
     record = Record.get_record(pid.object_uuid)
 
     e_tree, e_getrecord = verb(**kwargs)
+    e_record = SubElement(e_getrecord, etree.QName(NS_OAIPMH, 'record'))
 
     header(
-        e_getrecord,
+        e_record,
         identifier=str(pid.object_uuid),
         datestamp=record.updated,
         sets=record.get('_oai', {}).get('sets', []),
     )
-    e_metadata = SubElement(e_getrecord,
+    e_metadata = SubElement(e_record,
                             etree.QName(NS_OAIPMH, 'metadata'))
     e_metadata.append(record_dumper(pid, {'_source': record}))
 

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -147,20 +147,20 @@ def test_getrecord(app):
             assert len(tree.xpath('/x:OAI-PMH', namespaces=NAMESPACES)) == 1
             assert len(tree.xpath('/x:OAI-PMH/x:GetRecord',
                                   namespaces=NAMESPACES)) == 1
-            assert len(tree.xpath('/x:OAI-PMH/x:GetRecord/x:header',
+            assert len(tree.xpath('/x:OAI-PMH/x:GetRecord/x:record/x:header',
                                   namespaces=NAMESPACES)) == 1
             assert len(tree.xpath(
-                '/x:OAI-PMH/x:GetRecord/x:header/x:identifier',
+                '/x:OAI-PMH/x:GetRecord/x:record/x:header/x:identifier',
                 namespaces=NAMESPACES)) == 1
             identifier = tree.xpath(
-                '/x:OAI-PMH/x:GetRecord/x:header/x:identifier/text()',
+                '/x:OAI-PMH/x:GetRecord/x:record/x:header/x:identifier/text()',
                 namespaces=NAMESPACES)
             assert identifier == [str(record.id)]
             datestamp = tree.xpath(
-                '/x:OAI-PMH/x:GetRecord/x:header/x:datestamp/text()',
+                '/x:OAI-PMH/x:GetRecord/x:record/x:header/x:datestamp/text()',
                 namespaces=NAMESPACES)
             assert datestamp == [datetime_to_datestamp(record_updated)]
-            assert len(tree.xpath('/x:OAI-PMH/x:GetRecord/x:metadata',
+            assert len(tree.xpath('/x:OAI-PMH/x:GetRecord/x:record/x:metadata',
                                   namespaces=NAMESPACES)) == 1
 
 


### PR DESCRIPTION
* Fixes missing <record> envelope in GetRecord response. (closes #67)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>