### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-OAIServer.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-oaiserver
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_oaiserver/config.py
+++ b/invenio_oaiserver/config.py
@@ -40,7 +40,7 @@ OAISERVER_RECORD_INDEX = 'records'
 OAISERVER_PROTOCOL_VERSION = '2.0'
 
 OAISERVER_ADMIN_EMAILS = [
-    'info@invenio-software.org',
+    'info@inveniosoftware.org',
 ]
 """The e-mail addresses of administrators of the repository.
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     keywords='invenio OAI-PMH',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-oaiserver',
     packages=packages,
     zip_safe=False,

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -103,7 +103,7 @@ def test_identify(app):
         adminEmail = tree.xpath('/x:OAI-PMH/x:Identify/x:adminEmail',
                                 namespaces=NAMESPACES)
         assert len(adminEmail) == 1
-        assert adminEmail[0].text == 'info@invenio-software.org'
+        assert adminEmail[0].text == 'info@inveniosoftware.org'
         earliestDatestamp = tree.xpath(
             '/x:OAI-PMH/x:Identify/x:earliestDatestamp',
             namespaces=NAMESPACES)


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>