### PR TITLE
verbs: fix ListRecords with resumptionToken 

### DIFF
--- a/invenio_oaiserver/verbs.py
+++ b/invenio_oaiserver/verbs.py
@@ -131,6 +131,9 @@ class ResumptionVerbs(Verbs):
     class ListRecords(OAISchema, ResumptionTokenSchema):
         """Arguments for ListRecords verb."""
 
+        metadataPrefix = fields.Str(load_only=True,
+                                    validate=validate_metadata_prefix)
+
     class ListSets(OAISchema, ResumptionTokenSchema):
         """Arguments for ListSets verb."""
 

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -453,11 +453,11 @@ def test_listidentifiers(app):
         assert len(datestamp) == 1
         assert datestamp[0].text == record['_oai']['updated']
 
-        # Check from_:until range
+        # Check from:until range
         with app.test_client() as c:
             result = c.get(
                 '/oai2d?verb=ListIdentifiers&metadataPrefix=oai_dc'
-                '&from_={0}&until={1}&set=test0'.format(
+                '&from={0}&until={1}&set=test0'.format(
                     datetime_to_datestamp(record.updated - datetime.timedelta(
                         1)),
                     datetime_to_datestamp(record.updated + datetime.timedelta(


### PR DESCRIPTION
* Adds missing field `metadataPrefix` in `ListRecords` schema with
  resumption token.  (closes #88)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>