### PR TITLE
global: record signals and entry points setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,7 @@ known_first_party = invenio_oaiserver
 known_third_party = invenio_assets, invenio_db, invenio_indexer, invenio_pidstore, invenio_records, invenio_search, invenio_marc21, dojson
 multi_line_output = 2
 default_section = THIRDPARTY
+skip = .eggs
 
 # RST files (used by sphinx)
 [*.rst]

--- a/invenio_oaiserver/__init__.py
+++ b/invenio_oaiserver/__init__.py
@@ -70,6 +70,13 @@ you need to set following configuration options first:
 >>> from invenio_oaiserver import InvenioOAIServer
 >>> ext_oaiserver = InvenioOAIServer(app)
 
+Register the blueprint for OAIServer. If you use InvenioOAIServer as part of
+the invenio-base setup, the blueprint will be registered automatically through
+an entry point.
+
+>>> from invenio_oaiserver.views.server import blueprint
+>>> app.register_blueprint(blueprint)
+
 In order for the following examples to work, you need to work within an
 Flask application context so let's push one:
 

--- a/invenio_oaiserver/config.py
+++ b/invenio_oaiserver/config.py
@@ -133,3 +133,6 @@ OAISERVER_CACHE_KEY = 'DynamicOAISets::'
 
 OAISERVER_CELERY_TASK_CHUNK_SIZE = 100
 """Specify the maximum number of records each task will update."""
+
+OAISERVER_CONTROL_NUMBER_FETCHER = 'recid'
+"""PIDStore fetcher for the OAI ID control number."""

--- a/invenio_oaiserver/ext.py
+++ b/invenio_oaiserver/ext.py
@@ -118,12 +118,7 @@ class InvenioOAIServer(object):
         :param app: An instance of :class:`flask.Flask`.
         """
         self.init_config(app)
-
         state = _AppState(app=app, cache=kwargs.get('cache'))
-
-        from .views import server
-        app.register_blueprint(server.blueprint)
-
         app.extensions['invenio-oaiserver'] = state
 
     def init_config(self, app):

--- a/invenio_oaiserver/minters.py
+++ b/invenio_oaiserver/minters.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import, print_function
 from datetime import datetime
 
 from flask import current_app
+from invenio_pidstore import current_pidstore
 
 from .provider import OAIIDProvider
 from .utils import datetime_to_datestamp
@@ -43,9 +44,11 @@ def oaiid_minter(record_uuid, data):
     """
     pid_value = data.get('_oai', {}).get('id')
     if pid_value is None:
-        assert 'control_number' in data
+        fetcher_name = \
+            current_app.config.get('OAISERVER_CONTROL_NUMBER_FETCHER', 'recid')
+        cn_pid = current_pidstore.fetchers[fetcher_name](record_uuid, data)
         pid_value = current_app.config.get('OAISERVER_ID_PREFIX', '') + str(
-            data['control_number']
+            cn_pid.pid_value
         )
     provider = OAIIDProvider.create(
         object_type='rec', object_uuid=record_uuid,

--- a/invenio_oaiserver/minters.py
+++ b/invenio_oaiserver/minters.py
@@ -26,9 +26,12 @@
 
 from __future__ import absolute_import, print_function
 
+from datetime import datetime
+
 from flask import current_app
 
 from .provider import OAIIDProvider
+from .utils import datetime_to_datestamp
 
 
 def oaiid_minter(record_uuid, data):
@@ -50,4 +53,5 @@ def oaiid_minter(record_uuid, data):
     )
     data.setdefault('_oai', {})
     data['_oai']['id'] = provider.pid.pid_value
+    data['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
     return provider.pid

--- a/invenio_oaiserver/receivers.py
+++ b/invenio_oaiserver/receivers.py
@@ -113,11 +113,10 @@ class OAIServerUpdater(object):
         :param record: The record data.
         """
         if '_oai' in record and 'id' in record['_oai']:
-            old_sets = sorted(record['_oai'].get('sets', []))
-            new_sets = sorted(get_record_sets(
-                record=record, matcher=self.matcher))
-            # Sort old and new sets for false-positives coming from ordering
-            if old_sets != new_sets:
+            new_sets = get_record_sets(
+                record=record, matcher=self.matcher)
+            # Update only if old and new sets differ
+            if set(record['_oai'].get('sets', [])) != set(new_sets):
                 record['_oai'].update({
                     'sets': new_sets,
                     'updated': datetime_to_datestamp(datetime.utcnow()),

--- a/invenio_oaiserver/receivers.py
+++ b/invenio_oaiserver/receivers.py
@@ -94,8 +94,8 @@ def get_record_sets(record, matcher):
 
     output = set()
 
-    for sets in matcher(sets, record):
-        output |= sets
+    for matched_sets in matcher(sets, record):
+        output |= matched_sets
 
     return list(output)
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,9 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-
-pydocstyle invenio_oaiserver && \
-isort -rc -c -df **/*.py && \
+pydocstyle invenio_oaiserver tests && \
+isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,12 @@ setup(
         'invenio_base.apps': [
             'invenio_oaiserver = invenio_oaiserver:InvenioOAIServer',
         ],
+        'invenio_base.blueprints': [
+            'invenio_oaiserver = invenio_oaiserver.views.server:blueprint',
+        ],
+        'invenio_base.api_apps': [
+            'invenio_oaiserver = invenio_oaiserver:InvenioOAIServer',
+        ],
         'invenio_db.models': [
             'invenio_oaiserver = invenio_oaiserver.models',
         ],

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Tests data."""


### PR DESCRIPTION
* Sets are no longer created for records without OAIID, and
  'updated' timestamp is refreshed only when sets change.

* UI blueprint is now registered in entry point.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>