### PR TITLE
serialization: GetRecord method identifier fix

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,10 +28,6 @@ API Docs
 .. automodule:: invenio_oaiserver.ext
    :members:
 
-..
-   automodule:: invenio_oaiserver.proxies
-   :members:
-
 Models
 ------
 

--- a/invenio_oaiserver/response.py
+++ b/invenio_oaiserver/response.py
@@ -270,7 +270,7 @@ def getrecord(**kwargs):
 
     header(
         e_record,
-        identifier=str(pid.object_uuid),
+        identifier=pid.pid_value,
         datestamp=record.updated,
         sets=record.get('_oai', {}).get('sets', []),
     )

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,6 @@ tests_require = [
 ]
 
 extras_require = {
-    ':python_version=="2.7"': [
-        'functools32>=3.2.3',
-    ],
     'admin': [
         'Flask-Admin>=1.3.0',
     ],
@@ -58,7 +55,7 @@ extras_require = {
         'Flask-CeleryExt>=0.2.2',
     ],
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.5.2',
     ],
     'mysql': [
         'invenio-db[mysql]>=1.0.0b3',
@@ -89,6 +86,7 @@ install_requires = [
     'dojson>=1.2.0',
     'elasticsearch>=2.0.0,<3.0.0',
     'elasticsearch-dsl>=2.0.0,<3.0.0',
+    'functools32>=3.2.3-2; python_version=="2.7"',
     'invenio-pidstore>=1.0.0b1',
     'invenio-query-parser>=0.6.0',
     'invenio-records>=1.0.0b1',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ from sqlalchemy_utils.functions import create_database, database_exists, \
     drop_database
 from werkzeug.contrib.cache import SimpleCache
 
-from invenio_oaiserver import InvenioOAIServer, current_oaiserver
+from invenio_oaiserver import InvenioOAIServer
 from invenio_oaiserver.views.server import blueprint
 
 
@@ -144,6 +144,7 @@ def bibliographic_data(app):
 @pytest.yield_fixture
 def with_record_signals(app):
     """Enable the record insert/update signals for OAISets."""
+    from invenio_oaiserver import current_oaiserver
     current_oaiserver.register_signals()
     prev_cache = current_oaiserver.cache
     current_oaiserver.cache = SimpleCache()

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -155,7 +155,7 @@ def test_getrecord(app):
             identifier = tree.xpath(
                 '/x:OAI-PMH/x:GetRecord/x:record/x:header/x:identifier/text()',
                 namespaces=NAMESPACES)
-            assert identifier == [str(record.id)]
+            assert identifier == [pid_value]
             datestamp = tree.xpath(
                 '/x:OAI-PMH/x:GetRecord/x:record/x:header/x:datestamp/text()',
                 namespaces=NAMESPACES)


### PR DESCRIPTION
UUID was being serialized into the record identifier on the final XML instead of the pid_value, see: https://zenodo.org/oai2d?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:zenodo.org:167082
