### PR TITLE
global: oai.updated timestamp removal

### DIFF
--- a/invenio_oaiserver/minters.py
+++ b/invenio_oaiserver/minters.py
@@ -56,5 +56,4 @@ def oaiid_minter(record_uuid, data):
     )
     data.setdefault('_oai', {})
     data['_oai']['id'] = provider.pid.pid_value
-    data['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
     return provider.pid

--- a/invenio_oaiserver/models.py
+++ b/invenio_oaiserver/models.py
@@ -103,7 +103,6 @@ class OAISet(db.Model, Timestamp):
         assert not self.has_record(record)
 
         record['_oai']['sets'].append(self.spec)
-        record['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
 
     def remove_record(self, record):
         """Remove a record from the OAISet.
@@ -115,7 +114,6 @@ class OAISet(db.Model, Timestamp):
 
         record['_oai']['sets'] = [
             s for s in record['_oai']['sets'] if s != self.spec]
-        record['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
 
     def has_record(self, record):
         """Check if the record blongs to the OAISet.

--- a/invenio_oaiserver/query.py
+++ b/invenio_oaiserver/query.py
@@ -82,7 +82,7 @@ def get_affected_records(spec=None, search_pattern=None):
 
 
 def get_records(**kwargs):
-    """Get recordsi paginated."""
+    """Get records paginated."""
     page_ = kwargs.get('resumptionToken', {}).get('page', 1)
     size_ = current_app.config['OAISERVER_PAGE_SIZE']
     scroll = current_app.config['OAISERVER_RESUMPTION_TOKEN_EXPIRE_TIME']
@@ -106,7 +106,7 @@ def get_records(**kwargs):
         if 'until' in kwargs:
             time_range['lte'] = kwargs['until']
         if time_range:
-            search = search.filter('range', **{'_oai.updated': time_range})
+            search = search.filter('range', **{'_updated': time_range})
 
         response = search.execute().to_dict()
     else:
@@ -154,8 +154,8 @@ def get_records(**kwargs):
                         'id': result['_id'],
                         'json': result,
                         'updated': datetime.strptime(
-                            result['_source']['_oai']['updated'],
-                            '%Y-%m-%dT%H:%M:%SZ'
+                            result['_source']['_updated'][:19],
+                            '%Y-%m-%dT%H:%M:%S'
                         ),
                     }
 

--- a/invenio_oaiserver/receivers.py
+++ b/invenio_oaiserver/receivers.py
@@ -47,8 +47,7 @@ class OAIServerUpdater(object):
             # Update only if old and new sets differ
             if set(record['_oai'].get('sets', [])) != new_sets:
                 record['_oai'].update({
-                    'sets': list(new_sets),
-                    'updated': datetime_to_datestamp(datetime.utcnow()),
+                    'sets': list(new_sets)
                 })
 
 

--- a/invenio_oaiserver/schemas/oaiserver/internal-v1.1.0.json
+++ b/invenio_oaiserver/schemas/oaiserver/internal-v1.1.0.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "_oai": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "sets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,6 @@ def schema():
             },
         }, {
             '$ref': 'http://inveniosoftware.org/schemas/'
-                    'oaiserver/internal-v1.0.0.json',
+                    'oaiserver/internal-v1.1.0.json',
         }]
     }

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -501,7 +501,7 @@ def test_listidentifiers(app):
             namespaces=NAMESPACES
         )
         assert len(datestamp) == 1
-        assert datestamp[0].text == record['_oai']['updated']
+        assert datestamp[0].text == datetime_to_datestamp(record.updated)
 
         # Check from:until range
         with app.test_client() as c:


### PR DESCRIPTION
* Removes the separate timestamp that stored the update time in the
  _oai.updated field. It's not needed, because each time we touch the
  record, the value of record.updated is changed, so we can use it
  when creating the OAI set (closes #119).

* Adds a new JSON schema with 'updated' property removed.