### PR TITLE
docs: fix doctest rendering

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,2 +1,14 @@
 Installation
 ============
+
+Invenio-OAIServer is on PyPI so all you need is:
+
+.. code-block:: console
+
+   $ pip install invenio-oaiserver
+
+Invenio-OAIServer depends on Invenio-Search, Invenio-Records and Celery/Kombu.
+
+**Requirements**
+
+Invenio-OAIServer requires a message queue in addition to Elasticsearch (Invenio-Search) and a database (Invenio-Records). See Kombu documentation for list of supported message queues (e.g. RabbitMQ): http://kombu.readthedocs.io/en/latest/introduction.html#transport-comparison

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
--e .[docs,tests]
+-e .[docs,tests,sqlite]


### PR DESCRIPTION
* Adds installation guide.

* All `doctests` including `invenio-db` were not rendered because this
  package was missing from requirements (closes #127).