### PR TITLE
global: pin celery and fix default config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@
 
 addons:
   postgresql: 9.4
+  apt:
+    packages:
+    - rabbitmq-server
 
 notifications:
   email: false

--- a/invenio_oaiserver/config.py
+++ b/invenio_oaiserver/config.py
@@ -114,7 +114,7 @@ field."""
 OAISERVER_QUERY_PARSER = 'elasticsearch_dsl:Q'
 """Define query parser for OIASet definition."""
 
-OAISERVER_QUERY_PARSER_FIELDS = None
+OAISERVER_QUERY_PARSER_FIELDS = []
 """Define query parser search fields list for OIASet definition."""
 
 OAISERVER_CACHE_KEY = 'DynamicOAISets::'

--- a/invenio_oaiserver/query.py
+++ b/invenio_oaiserver/query.py
@@ -25,7 +25,8 @@ def query_string_parser(search_pattern):
         if isinstance(query_parser, six.string_types):
             query_parser = import_string(query_parser)
         current_oaiserver.query_parser = query_parser
-    query_parser_fields = current_app.config['OAISERVER_QUERY_PARSER_FIELDS']
+    query_parser_fields = current_app.config.get(
+        'OAISERVER_QUERY_PARSER_FIELDS', {}) or {}
     if query_parser_fields:
         query_parser_fields = dict(fields=query_parser_fields)
     return current_oaiserver.query_parser(

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ extras_require = {
         'Flask-Admin>=1.3.0',
     ],
     'celery': [
-        'Flask-CeleryExt>=0.3.0',
+        # Avoid version 4.3 it breaks the emails with datetime
+        # https://github.com/celery/celery/pull/5606
+        "celery>=4.2.1,<4.3.0",
+        'Flask-CeleryExt>=0.3.2',
     ],
     'docs': [
         'Sphinx>=1.6.7',

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ extras_require = {
         'Flask-Admin>=1.3.0',
     ],
     'celery': [
-        # Avoid version 4.3 it breaks the emails with datetime
-        # https://github.com/celery/celery/pull/5606
-        "celery>=4.2.1,<4.3.0",
-        'Flask-CeleryExt>=0.3.2',
+        'invenio-celery>=1.1.1',
     ],
     'docs': [
         'Sphinx>=1.6.7',


### PR DESCRIPTION
- default for `OAISERVER_QUERY_PARSER_FIELDS`
- pinned celery less than 4.3