### PR TITLE
OpenSearch 2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,9 @@ jobs:
       matrix:
           python-version: [3.7, 3.8, 3.9]
           requirements-level: [pypi]
-          db-service: [postgresql10, postgresql13, mysql8]
-          mq-service: [rabbitmq, redis]
-          search-service: [opensearch1,elasticsearch7]
+          db-service: [postgresql10,postgresql13,mysql8]
+          mq-service: [rabbitmq,redis]
+          search-service: [opensearch2,elasticsearch7]
           exclude:
           - db-service: postgresql10
             python-version: 3.7
@@ -42,7 +42,7 @@ jobs:
           - db-service: postgresql13
             python-version: 3.7
 
-          - search-service: opensearch1
+          - search-service: opensearch2
             python-version: 3.7
 
           - search-service: elasticsearch7

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,18 +39,20 @@ install_requires =
 [options.extras_require]
 tests =
     pytest-black>=0.3.0
-    invenio-indexer>=2.0.0,<3.0.0
+    invenio-indexer>=2.1.0,<3.0.0
     invenio-jsonschemas>=1.1.3,<2.0.0
     mock>=1.3.0
-    pytest-invenio>=2.0.0,<3.0.0
+    pytest-invenio>=2.1.0,<3.0.0
     invenio-admin>=1.3.0,<2.0.0
-    invenio-celery>=1.2.3,<2.0.0
+    invenio-celery>=1.2.5,<2.0.0
     Sphinx>=4.5.0
     invenio-db[mysql,postgresql,versioning]>=1.0.9,<2.0.0
 elasticsearch7 =
-    invenio-search[elasticsearch7]>=2.0.0,<3.0.0
+    invenio-search[elasticsearch7]>=2.1.0,<3.0.0
 opensearch1 =
-    invenio-search[opensearch1]>=2.0.0,<3.0.0
+    invenio-search[opensearch1]>=2.1.0,<3.0.0
+opensearch2 =
+    invenio-search[opensearch2]>=2.1.0,<3.0.0
 
 [options.entry_points]
 invenio_base.apps =

--- a/tests/data/os-v2/__init__.py
+++ b/tests/data/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests data."""

--- a/tests/data/os-v2/records/record-v1.0.0.json
+++ b/tests/data/os-v2/records/record-v1.0.0.json
@@ -1,0 +1,34 @@
+{
+  "mappings": {
+    "_source" : { "enabled" : true },
+    "properties" : {
+      "title_statement": {
+        "properties": {
+          "title": {
+            "type": "text"
+          },
+          "body": {
+            "type": "text"
+          }
+        }
+      },
+      "_oai": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "sets": {
+            "type": "keyword"
+          }
+        }
+      },
+      "genre": {
+        "type": "text"
+      },
+      "_created": {
+        "type": "date"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add support for OpenSearch 2.x by dropping references to `doc_type`s

Drops the `schema_to_index` use from `invenio-indexer` (relevant for this PR: https://github.com/inveniosoftware/invenio-indexer/pull/142)

Requires:
* https://github.com/inveniosoftware/invenio-search/pull/222
* https://github.com/inveniosoftware/invenio-indexer/pull/142
* https://github.com/inveniosoftware/dojson/pull/207 (for Python 3.10)