### PR TITLE
Fix percolator deletion for lazy strings and release v2.2.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version v2.2.3 (released 2024-09-25)
+
+- percolator: allow lazy strings from config for deletions
+
 Version v2.2.2 (released 2024-09-11)
 
 - percolator: allow lazy strings from config

--- a/invenio_oaiserver/__init__.py
+++ b/invenio_oaiserver/__init__.py
@@ -185,6 +185,6 @@ repository
 from .ext import InvenioOAIServer
 from .proxies import current_oaiserver
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 __all__ = ("__version__", "InvenioOAIServer", "current_oaiserver")

--- a/invenio_oaiserver/percolator.py
+++ b/invenio_oaiserver/percolator.py
@@ -73,7 +73,8 @@ def _new_percolator(spec, search_pattern):
 
 def _delete_percolator(spec, search_pattern):
     """Delete percolator associated with the removed/updated oaiset."""
-    oai_records_index = current_app.config["OAISERVER_RECORD_INDEX"]
+    # NOTE: We call `str` so that we can also handle lazy values (e.g. a LocalProxy)
+    oai_records_index = str(current_app.config["OAISERVER_RECORD_INDEX"])
     # Create the percolator doc_type in the existing index for >= ES5
     for index, mapping_path in current_search.mappings.items():
         # Skip indices/mappings not used by OAI-PMH


### PR DESCRIPTION
- **percolator: allow lazy strings from config for deletions**
- **📦 release: v2.2.3**
