### PR TITLE
percolator: use `OAISERVER_RECORD_INDEX` to determine percolator index

### DIFF
--- a/invenio_oaiserver/percolator.py
+++ b/invenio_oaiserver/percolator.py
@@ -12,7 +12,6 @@
 import json
 
 from flask import current_app
-from invenio_indexer.api import RecordIndexer
 from invenio_search import current_search, current_search_client
 from invenio_search.engine import search
 from invenio_search.utils import build_index_name
@@ -166,8 +165,8 @@ def sets_search_all(records):
     if not records:
         return []
 
-    # TODO: records should all have the same index. maybe add index as parameter?
-    record_index = RecordIndexer()._record_to_index(records[0])
+    record_index = str(current_app.config["OAISERVER_RECORD_INDEX"])
+    # TODO: We shouldn't have to always create the percolator mapping here
     _create_percolator_mapping(record_index)
     percolator_index = _build_percolator_index_name(record_index)
     record_sets = [[] for _ in range(len(records))]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,9 +50,10 @@ def app():
         ),
         SQLALCHEMY_TRACK_MODIFICATIONS=True,
         SERVER_NAME="app",
+        INDEXER_DEFAULT_INDEX="records-record-v1.0.0",
         OAISERVER_ID_PREFIX="oai:inveniosoftware.org:recid/",
         OAISERVER_QUERY_PARSER_FIELDS=["title_statement"],
-        OAISERVER_RECORD_INDEX="_all",
+        OAISERVER_RECORD_INDEX="records-record-v1.0.0",
         OAISERVER_REGISTER_SET_SIGNALS=True,
     )
     if not hasattr(app, "cli"):


### PR DESCRIPTION
* Instead of relying on the default `RecordIndexer` class to determine
  the percolator index, we reuse the `OAISERVER_RECORD_INDEX` config variable.
