### PR TITLE
component_templates: allow the usage of component_templates instead of mappings for the definition of the records.

### DIFF
--- a/invenio_oaiserver/percolator.py
+++ b/invenio_oaiserver/percolator.py
@@ -21,29 +21,28 @@ from invenio_oaiserver.query import query_string_parser
 
 def _build_percolator_index_name(index):
     """Build percolator index name."""
-    suffix = "-percolators"
-    return build_index_name(index, suffix=suffix, app=current_app)
+    # For backward compatibility only: percolators used to be written into a different index, with the suffix
+    # `-percolators`. In recent versions, the percolators can coexist in the same indices as the records
 
+    percolator_index = build_index_name(index, suffix="", app=current_app)
+    if current_search_client.indices.exists(f"{percolator_index}-percolators"):
+        percolator_index = f"{percolator_index}-percolators"
 
-def _create_percolator_mapping(index, mapping_path=None):
-    """Update mappings with the percolator field.
-
-    .. note::
-
-        This is only needed from ElasticSearch v5 onwards, because percolators
-        are now just a special type of field inside mappings.
-    """
-    percolator_index = _build_percolator_index_name(index)
-    if not mapping_path:
-        mapping_path = current_search.mappings[index]
-    if not current_search_client.indices.exists(percolator_index):
-        with open(mapping_path, "r") as body:
-            mapping = json.load(body)
-            mapping["mappings"]["properties"].update(PERCOLATOR_MAPPING["properties"])
-            current_search_client.indices.create(index=percolator_index, body=mapping)
-
-
-PERCOLATOR_MAPPING = {"properties": {"query": {"type": "percolator"}}}
+    # Let's check as well that the mapping for `query` exists. It would be better if this was done only once
+    # The main issue is that the first time could be either creating a set, or querying if a record is in any set
+    mapping = current_search_client.indices.get_field_mapping(
+        index=percolator_index, fields="query"
+    )
+    if (
+        not percolator_index in mapping
+        or "query" not in mapping[percolator_index]["mappings"]
+    ):
+        # The field is not there. Adding the mapping
+        current_search_client.indices.put_mapping(
+            index=percolator_index,
+            body={"properties": {"query": {"type": "percolator"}}},
+        )
+    return percolator_index
 
 
 def _new_percolator(spec, search_pattern):
@@ -53,16 +52,16 @@ def _new_percolator(spec, search_pattern):
 
         # NOTE: We call `str` so that we can also handle lazy values (e.g. a LocalProxy)
         oai_records_index = str(current_app.config["OAISERVER_RECORD_INDEX"])
-        for index, mapping_path in current_search.mappings.items():
+        for index, _ in (
+            current_search.mappings.items() | current_search.index_templates.items()
+        ):
             # Skip indices/mappings not used by OAI-PMH
             if not index.startswith(oai_records_index):
                 continue
-            # Create the percolator doc_type in the existing index for >= ES5
-            # TODO: Consider doing this only once in app initialization
             try:
-                _create_percolator_mapping(index, mapping_path)
+                percolator_index = _build_percolator_index_name(index)
                 current_search_client.index(
-                    index=_build_percolator_index_name(index),
+                    index=percolator_index,
                     id="oaiset-{}".format(spec),
                     body={"query": query},
                 )
@@ -75,7 +74,9 @@ def _delete_percolator(spec, search_pattern):
     # NOTE: We call `str` so that we can also handle lazy values (e.g. a LocalProxy)
     oai_records_index = str(current_app.config["OAISERVER_RECORD_INDEX"])
     # Create the percolator doc_type in the existing index for >= ES5
-    for index, mapping_path in current_search.mappings.items():
+    for index, _ in (
+        current_search.mappings.items() | current_search.index_templates.items()
+    ):
         # Skip indices/mappings not used by OAI-PMH
         if not index.startswith(oai_records_index):
             continue
@@ -166,13 +167,9 @@ def sets_search_all(records):
         return []
 
     record_index = str(current_app.config["OAISERVER_RECORD_INDEX"])
-    # TODO: We shouldn't have to always create the percolator mapping here
-    _create_percolator_mapping(record_index)
     percolator_index = _build_percolator_index_name(record_index)
     record_sets = [[] for _ in range(len(records))]
-
     result = percolate_query(percolator_index, documents=records)
-
     prefix = "oaiset-"
     prefix_len = len(prefix)
 

--- a/invenio_oaiserver/search/__init__.py
+++ b/invenio_oaiserver/search/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module with JSON schemas for an internal ``_oai`` field."""

--- a/invenio_oaiserver/search/component_templates/__init__.py
+++ b/invenio_oaiserver/search/component_templates/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module with JSON schemas for an internal ``_oai`` field."""

--- a/invenio_oaiserver/search/component_templates/os-v2/__init__.py
+++ b/invenio_oaiserver/search/component_templates/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module with JSON schemas for an internal ``_oai`` field."""

--- a/invenio_oaiserver/search/component_templates/os-v2/oairecord-v1.0.0.json
+++ b/invenio_oaiserver/search/component_templates/os-v2/oairecord-v1.0.0.json
@@ -1,0 +1,22 @@
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "pids": {
+          "properties": {
+            "oai": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "query": {
+          "type": "percolator"
+        }
+      }
+    }
+  }
+}

--- a/invenio_oaiserver/utils.py
+++ b/invenio_oaiserver/utils.py
@@ -177,7 +177,7 @@ def sanitize_unicode(value):
     Following W3C recommandation : https://www.w3.org/TR/REC-xml/#charsets
     Based on https://lsimons.wordpress.com/2011/03/17/stripping-illegal-characters-out-of-xml-in-python/ # noqa
     """
-    return re.sub("[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]", "", value)
+    return re.sub("[\x00-\x08\x0b\x0c\x0e-\x1f\ud800-\udfff\ufffe\uffff]", "", value)
 
 
 def record_sets_fetcher(record):

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,8 @@ invenio_pidstore.minters =
     oaiid = invenio_oaiserver.minters:oaiid_minter
 invenio_pidstore.fetchers =
     oaiid = invenio_oaiserver.fetchers:oaiid_fetcher
+invenio_search.component_templates =
+    oairecord = invenio_oaiserver.search.component_templates
 
 [build_sphinx]
 source-dir = docs/

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,5 +24,4 @@ def test_version():
 def test_init():
     """Test extension initialization."""
     app = Flask("testapp")
-    with pytest.warns(None):
-        InvenioOAIServer(app)
+    InvenioOAIServer(app)


### PR DESCRIPTION
invenio-search offers the possibility of using component_templates to define an object, instead of defining the full mappings.

This is currently used in opendata (see [example](https://github.com/cernopendata/cernopendata-portal/tree/main/cernopendata/modules/search/component_templates/os-v2)) . Then, a particular index can pick and choose the components that it needs  (see [opendata example](https://github.com/cernopendata/cernopendata-portal/blob/main/cernopendata/modules/search/index_templates/os-v2/records/docs-v1.0.0.json)).    

This PR introduces a component template that oai-records can use. If they go this way, there is no longer the need for the index called `<record>-percolator`, since it will be stored in the same index as the data.