### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_oaiserver/config.py
+++ b/invenio_oaiserver/config.py
@@ -2,15 +2,17 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """The details of the configuration options for OAI-PMH server."""
 
+import os
+from importlib.resources import files
+
 import invenio_search
-import pkg_resources
 
 OAISERVER_PAGE_SIZE = 10
 """Define maximum length of list responses.
@@ -70,8 +72,8 @@ OAISERVER_METADATA_FORMATS = {
         "serializer": (
             "invenio_oaiserver.utils:dumps_etree",
             {
-                "xslt_filename": pkg_resources.resource_filename(
-                    "invenio_oaiserver", "static/xsl/MARC21slim2OAIDC.xsl"
+                "xslt_filename": os.path.join(
+                    files("invenio_oaiserver"), "static/xsl/MARC21slim2OAIDC.xsl"
                 ),
             },
         ),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,9 +11,9 @@
 """Utilities for loading test records."""
 
 import uuid
+from importlib.resources import files
 
 import mock
-import pkg_resources
 from dojson.contrib.marc21 import marc21
 from dojson.contrib.marc21.utils import load
 from invenio_db import db
@@ -34,7 +35,7 @@ def load_records(app, filename, schema, tries=5):
     records = []
     with app.app_context():
         with mock.patch("invenio_records.api.Record.validate", return_value=None):
-            data_filename = pkg_resources.resource_filename("invenio_records", filename)
+            data_filename = files("invenio_records") / filename
             records_data = load(data_filename)
             with db.session.begin_nested():
                 for item in records_data:


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
