### PR TITLE
fix: Align server default for system_created

### DIFF
--- a/invenio_oaiserver/models.py
+++ b/invenio_oaiserver/models.py
@@ -4,12 +4,14 @@
 # Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2022-2026 Graz University of Technology.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Models for storing information about OAIServer state."""
 
+import sqlalchemy as sa
 from invenio_db import db
 from invenio_i18n import lazy_gettext as _
 from sqlalchemy.orm import validates
@@ -68,6 +70,7 @@ class OAISet(db.Model, db.Timestamp):
     system_created = db.Column(
         db.Boolean,
         nullable=False,
+        server_default=sa.sql.expression.literal(False),
         info=dict(
             label=_("System created"),
             description=_("System created set"),

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-oaiserver is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Test invenio-oaiserver alembic."""
+
+import pytest
+from invenio_db import db
+from invenio_db.utils import alembic_test_context, drop_alembic_version_table
+
+
+def test_alembic(app):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
+
+    # Check that this package's SQLAlchemy models have been properly registered
+    tables = [x for x in db.metadata.tables]
+    assert "oaiserver_set" in tables
+
+    # Check that Alembic agrees that there's no further tables to create.
+    assert len(ext.alembic.compare_metadata()) == 0
+
+    # Drop everything and recreate tables all with Alembic
+    db.drop_all()
+    drop_alembic_version_table()
+    ext.alembic.upgrade()
+    assert len(ext.alembic.compare_metadata()) == 0
+
+    drop_alembic_version_table()


### PR DESCRIPTION

### Description

This PR aligns database schema (from alembic migrations) with the Python column definition by adding a server-side default on the database definition that is already present in alembic migrations.

Note: tests need https://github.com/inveniosoftware/invenio-accounts/pull/551 to succeed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
