### PR TITLE
feat: add support for OAI about serializer

### DIFF
--- a/invenio_oaiserver/response.py
+++ b/invenio_oaiserver/response.py
@@ -23,7 +23,12 @@ from .provider import OAIIDProvider
 from .proxies import current_oaiserver
 from .query import get_records
 from .resumption_token import serialize
-from .utils import datetime_to_datestamp, sanitize_unicode, serializer
+from .utils import (
+    about_serializer,
+    datetime_to_datestamp,
+    sanitize_unicode,
+    serializer,
+)
 
 NS_OAIPMH = "http://www.openarchives.org/OAI/2.0/"
 NS_OAIPMH_XSD = "http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"
@@ -256,6 +261,7 @@ def header(parent, identifier, datestamp, sets=None, deleted=False):
 def getrecord(**kwargs):
     """Create OAI-PMH response for verb Identify."""
     record_dumper = serializer(kwargs["metadataPrefix"])
+    about_dumper = about_serializer(kwargs["metadataPrefix"])
 
     pid = OAIIDProvider.get(pid_value=kwargs["identifier"]).pid
     record = current_oaiserver.record_fetcher(pid.object_uuid)
@@ -271,6 +277,11 @@ def getrecord(**kwargs):
     )
     e_metadata = SubElement(e_record, etree.QName(NS_OAIPMH, "metadata"))
     e_metadata.append(record_dumper(pid, {"_source": record}))
+    if about_dumper:
+        about_payload = about_dumper(pid, {"_source": record})
+        if about_payload is not None:
+            e_about = SubElement(e_record, etree.QName(NS_OAIPMH, "about"))
+            e_about.append(about_payload)
 
     return e_tree
 
@@ -304,6 +315,7 @@ def listrecords(**kwargs):
         else kwargs["metadataPrefix"]
     )
     record_dumper = serializer(metadataPrefix)
+    about_dumper = about_serializer(metadataPrefix)
 
     e_tree, e_listrecords = verb(**kwargs)
     result = get_records(**kwargs)
@@ -322,6 +334,11 @@ def listrecords(**kwargs):
         )
         e_metadata = SubElement(e_record, etree.QName(NS_OAIPMH, "metadata"))
         e_metadata.append(record_dumper(pid, record["json"]))
+        if about_dumper:
+            about_payload = about_dumper(pid, record["json"])
+            if about_payload is not None:
+                e_about = SubElement(e_record, etree.QName(NS_OAIPMH, "about"))
+                e_about.append(about_payload)
 
     resumption_token(e_listrecords, result, **kwargs)
     return e_tree

--- a/invenio_oaiserver/response.py
+++ b/invenio_oaiserver/response.py
@@ -261,7 +261,6 @@ def header(parent, identifier, datestamp, sets=None, deleted=False):
 def getrecord(**kwargs):
     """Create OAI-PMH response for verb Identify."""
     record_dumper = serializer(kwargs["metadataPrefix"])
-    about_dumper = about_serializer(kwargs["metadataPrefix"])
 
     pid = OAIIDProvider.get(pid_value=kwargs["identifier"]).pid
     record = current_oaiserver.record_fetcher(pid.object_uuid)
@@ -277,6 +276,8 @@ def getrecord(**kwargs):
     )
     e_metadata = SubElement(e_record, etree.QName(NS_OAIPMH, "metadata"))
     e_metadata.append(record_dumper(pid, {"_source": record}))
+    about_dumper = about_serializer(kwargs["metadataPrefix"])
+
     if about_dumper:
         about_payload = about_dumper(pid, {"_source": record})
         if about_payload is not None:
@@ -314,14 +315,15 @@ def listrecords(**kwargs):
         if kwargs.get("resumptionToken")
         else kwargs["metadataPrefix"]
     )
-    record_dumper = serializer(metadataPrefix)
-    about_dumper = about_serializer(metadataPrefix)
 
     e_tree, e_listrecords = verb(**kwargs)
     result = get_records(**kwargs)
 
     all_records = [record for record in result.items]
     records_sets = sets_search_all([r["json"]["_source"] for r in all_records])
+
+    record_dumper = serializer(metadataPrefix)
+    about_dumper = about_serializer(metadataPrefix)
 
     for index, record in enumerate(all_records):
         pid = current_oaiserver.oaiid_fetcher(record["id"], record["json"]["_source"])

--- a/invenio_oaiserver/utils.py
+++ b/invenio_oaiserver/utils.py
@@ -59,9 +59,7 @@ def about_serializer(metadata_prefix):
     :param metadata_prefix: One of the metadata identifiers configured in
              ``OAISERVER_METADATA_FORMATS``.
     """
-    return _resolve_serializer_value(
-        metadata_prefix, key="about_serializer", default=None
-    )
+    return _resolve_serializer_value(metadata_prefix, key="about_serializer")
 
 
 @lru_cache(maxsize=100)

--- a/invenio_oaiserver/utils.py
+++ b/invenio_oaiserver/utils.py
@@ -41,6 +41,29 @@ FRIENDS_SCHEMA_LOCATION = "http://www.openarchives.org/OAI/2.0/friends/"
 FRIENDS_SCHEMA_LOCATION_XSD = "http://www.openarchives.org/OAI/2.0/friends/.xsd"
 
 
+def _resolve_serializer_value(metadata_prefix, key, default=None):
+    """Resolve serializer config value into callable/object."""
+    metadata_formats = current_app.config["OAISERVER_METADATA_FORMATS"]
+    serializer_value = metadata_formats[metadata_prefix].get(key, default)
+    if isinstance(serializer_value, tuple):
+        return partial(obj_or_import_string(serializer_value[0]), **serializer_value[1])
+    if serializer_value:
+        return obj_or_import_string(serializer_value)
+    return serializer_value
+
+
+@lru_cache(maxsize=100)
+def about_serializer(metadata_prefix):
+    """Return about serializer instances.
+
+    :param metadata_prefix: One of the metadata identifiers configured in
+             ``OAISERVER_METADATA_FORMATS``.
+    """
+    return _resolve_serializer_value(
+        metadata_prefix, key="about_serializer", default=None
+    )
+
+
 @lru_cache(maxsize=100)
 def serializer(metadata_prefix):
     """Return etree_dumper instances.
@@ -48,11 +71,7 @@ def serializer(metadata_prefix):
     :param metadata_prefix: One of the metadata identifiers configured in
         ``OAISERVER_METADATA_FORMATS``.
     """
-    metadataFormats = current_app.config["OAISERVER_METADATA_FORMATS"]
-    serializer_ = metadataFormats[metadata_prefix]["serializer"]
-    if isinstance(serializer_, tuple):
-        return partial(obj_or_import_string(serializer_[0]), **serializer_[1])
-    return obj_or_import_string(serializer_)
+    return _resolve_serializer_value(metadata_prefix, key="serializer")
 
 
 def dumps_etree(pid, record, **kwargs):

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -338,6 +338,9 @@ def test_getrecord_with_about(app):
         "about_serializer"
     ] = _about_serializer_helper
 
+    serializer.cache_clear()
+    about_serializer.cache_clear()
+
     with app.test_request_context():
         pid_value = "oai:legacy:about-1"
         with db.session.begin_nested():

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -28,10 +28,12 @@ from invenio_oaiserver.models import OAISet
 from invenio_oaiserver.proxies import current_oaiserver
 from invenio_oaiserver.response import NS_DC, NS_OAIDC, NS_OAIPMH
 from invenio_oaiserver.utils import (
+    about_serializer,
     datetime_to_datestamp,
     eprints_description,
     friends_description,
     oai_identifier_description,
+    serializer,
 )
 
 NAMESPACES = {"x": NS_OAIPMH, "y": NS_OAIDC, "z": NS_DC}
@@ -321,6 +323,58 @@ def test_getrecord(app):
                 )
                 == 1
             )
+
+
+def _about_serializer_helper(pid, record):
+    element = etree.Element("test-about")
+    element.text = "about payload"
+    return element
+
+
+def test_getrecord_with_about(app):
+    """Test get record verb with about serializer."""
+
+    app.config["OAISERVER_METADATA_FORMATS"]["oai_dc"][
+        "about_serializer"
+    ] = _about_serializer_helper
+
+    with app.test_request_context():
+        pid_value = "oai:legacy:about-1"
+        with db.session.begin_nested():
+            record_id = uuid.uuid4()
+            data = {
+                "_oai": {"id": pid_value},
+                "title_statement": {"title": "Test about"},
+            }
+            pid = oaiid_minter(record_id, data)
+            current_oaiserver.record_cls.create(data, id_=record_id)
+
+        db.session.commit()
+        assert pid_value == pid.pid_value
+        with app.test_client() as c:
+            result = c.get(
+                "/oai2d?verb=GetRecord&identifier={0}&metadataPrefix=oai_dc".format(
+                    pid_value
+                )
+            )
+            assert 200 == result.status_code
+
+            tree = etree.fromstring(result.data)
+
+            assert (
+                len(
+                    tree.xpath(
+                        "/x:OAI-PMH/x:GetRecord/x:record/x:about",
+                        namespaces=NAMESPACES,
+                    )
+                )
+                == 1
+            )
+
+            assert tree.xpath(
+                "/x:OAI-PMH/x:GetRecord/x:record/x:about/x:test-about/text()",
+                namespaces=NAMESPACES,
+            ) == ["about payload"]
 
 
 def test_getrecord_fail(app):


### PR DESCRIPTION
### Description

 Add support for an optional `about_serializer` in OAI metadata format configuration.

  - resolve optional `about_serializer` from `OAISERVER_METADATA_FORMATS`
  - include `<about>` in `GetRecord` responses when configured
  - include `<about>` in `ListRecords` responses when configured
  - add test coverage for `GetRecord`

  This allows metadata formats to attach additional OAI-PMH `<about>` content alongside serialized metadata.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
